### PR TITLE
HistogramLogs with single Tag written by HistogramLogWriter can be processed

### DIFF
--- a/src/main/java/org/HdrHistogram/HistogramLogAnalyzer/charts/BucketsChartBuilder.java
+++ b/src/main/java/org/HdrHistogram/HistogramLogAnalyzer/charts/BucketsChartBuilder.java
@@ -212,8 +212,12 @@ public class BucketsChartBuilder {
 
             boolean multipleTags = tags.size() > 1;
             if (!multipleTags) {
+                String tag = null;
+                if(!tags.isEmpty()) {
+                    tag = tags.iterator().next();
+                }
                 XYSeries series = new XYSeries(DEFAULT_KEY);
-                BucketIterator bi = histogramModel.listBucketObjects(null);
+                BucketIterator bi = histogramModel.listBucketObjects(tag);
                 while (bi.hasNext()) {
                     BucketObject bo = (BucketObject) bi.next();
                     double hiccupValue = bo.getLatencyValue();
@@ -226,7 +230,7 @@ public class BucketsChartBuilder {
                 ret.addSeries(series);
 
                 // HPL lines (vertical lines actually but let's use HPL for consistency)
-                Iterator<PercentileObject> pi = histogramModel.listHPLPercentileObjects(null);
+                Iterator<PercentileObject> pi = histogramModel.listHPLPercentileObjects(tag);
                 while (pi.hasNext()) {
                     PercentileObject po = pi.next();
                     String key = String.valueOf(po.getPercentileValue() * 100);
@@ -242,7 +246,7 @@ public class BucketsChartBuilder {
 
                 // Max line
                 Double maxLatencyAxisValue = 0.0;
-                MaxPercentileIterator mpi = histogramModel.listMaxPercentileObjects(null);
+                MaxPercentileIterator mpi = histogramModel.listMaxPercentileObjects(tag);
                 PercentileObject mpo;
                 while (mpi.hasNext()) {
                     mpo = mpi.next();

--- a/src/main/java/org/HdrHistogram/HistogramLogAnalyzer/charts/TimelineDatasetBuilder.java
+++ b/src/main/java/org/HdrHistogram/HistogramLogAnalyzer/charts/TimelineDatasetBuilder.java
@@ -50,6 +50,10 @@ class TimelineDatasetBuilder {
 
             boolean multipleTags = tags.size() > 1;
             if (!multipleTags) {
+                String tag = null;
+                if(!tags.isEmpty()) {
+                    tag = tags.iterator().next();
+                }
                 MWPProperties mwpProperties = histogramModel.getMwpProperties();
                 List<MWPProperties.MWPEntry> mwpEntries = mwpProperties.getMWPEntries();
                 for (MWPProperties.MWPEntry mwpEntry : mwpEntries) {
@@ -62,7 +66,7 @@ class TimelineDatasetBuilder {
 
                     double startTime = histogramModel.getStartTimeSec();
                     CommonSeries series = createSeries(key, chartType);
-                    TimelineIterator ti = histogramModel.listTimelineObjects(false, null, mwpEntry);
+                    TimelineIterator ti = histogramModel.listTimelineObjects(false, tag, mwpEntry);
                     while (ti.hasNext()) {
                         TimelineObject to = ti.next();
                         series.add(to, startTime);
@@ -71,7 +75,7 @@ class TimelineDatasetBuilder {
                 }
 
                 // HPL lines
-                Iterator<PercentileObject> pi = histogramModel.listHPLPercentileObjects(null);
+                Iterator<PercentileObject> pi = histogramModel.listHPLPercentileObjects(tag);
                 while (pi.hasNext()) {
                     PercentileObject po = pi.next();
                     String key = String.valueOf(po.getPercentileValue() * 100);


### PR DESCRIPTION
A HistogramLog that contains one or more Histograms that have the same label throws the exception:
`java.lang.NullPointerException
        at org.HdrHistogram.HistogramLogAnalyzer.datalayer.HistogramModel.listHPLPercentileObjects(HistogramModel.java:353)
        at org.HdrHistogram.HistogramLogAnalyzer.charts.TimelineDatasetBuilder.build(TimelineDatasetBuilder.java:74)
        at org.HdrHistogram.HistogramLogAnalyzer.charts.TimelineChartBuilder.createTimelineDrawable(TimelineChartBuilder.java:230)
        at org.HdrHistogram.HistogramLogAnalyzer.charts.TimelineChartBuilder.createTimelineChart(TimelineChartBuilder.java:47)
        at org.HdrHistogram.HistogramLogAnalyzer.applicationlayer.HLAPanel.createTopChart(HLAPanel.java:195)
        at org.HdrHistogram.HistogramLogAnalyzer.applicationlayer.HLAPanel.<init>(HLAPanel.java:86)
        at org.HdrHistogram.HistogramLogAnalyzer.applicationlayer.HLATabbedPane.plotInputFiles(HLATabbedPane.java:36)
        at org.HdrHistogram.HistogramLogAnalyzer.applicationlayer.Application.run(Application.java:868)
        at org.HdrHistogram.HistogramLogAnalyzer.applicationlayer.Application.openFiles(Application.java:86)
        at org.HdrHistogram.HistogramLogAnalyzer.applicationlayer.Application.openHandler(Application.java:352)
        at org.HdrHistogram.HistogramLogAnalyzer.applicationlayer.Application.actionPerformed(Application.java:297)
        at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:2022)
        at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2348)
        at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:402)
        at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:259)
        at javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:252)
        at java.awt.Component.processMouseEvent(Component.java:6533)
        at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
        at java.awt.Component.processEvent(Component.java:6298)
        at java.awt.Container.processEvent(Container.java:2236)
        at java.awt.Component.dispatchEventImpl(Component.java:4889)
        at java.awt.Container.dispatchEventImpl(Container.java:2294)
        at java.awt.Component.dispatchEvent(Component.java:4711)
        at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4888)
        at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4525)
        at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4466)
        at java.awt.Container.dispatchEventImpl(Container.java:2280)
        at java.awt.Window.dispatchEventImpl(Window.java:2746)
        at java.awt.Component.dispatchEvent(Component.java:4711)
        at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
        at java.awt.EventQueue.access$500(EventQueue.java:97)
        at java.awt.EventQueue$3.run(EventQueue.java:709)
`

This PullRequest provides a fix. Attached is a file that reproduces the issue.

[hist.log](https://github.com/HdrHistogram/HistogramLogAnalyzer/files/5358308/hist.log)
